### PR TITLE
Rewrite SQL mode to remove regex lookbehind

### DIFF
--- a/src/lookml.js
+++ b/src/lookml.js
@@ -31,10 +31,8 @@ export default function (hljs) {
             hljs.HASH_COMMENT_MODE,
             "self",
             {
-                scope: "sql",
-                begin: /(?<=sql\w*\s*:)/,
-                end: /;;/,
-                endScope: "punctuation",
+                begin: [/sql\w*\s*:/, /.*/, /;;/],
+                beginScope: { 1: "keyword", 2: "sql", 3: "punctuation" },
                 contains: [
                     hljs.QUOTE_STRING_MODE,
                     {

--- a/src/lookml.js
+++ b/src/lookml.js
@@ -31,7 +31,7 @@ export default function (hljs) {
             hljs.HASH_COMMENT_MODE,
             "self",
             {
-                begin: [/sql\w*\s*:/, /.*/, /;;/],
+                begin: [/sql\w*\s*:/, /.*?/, /;;/],
                 beginScope: { 1: "keyword", 2: "sql", 3: "punctuation" },
                 contains: [
                     hljs.QUOTE_STRING_MODE,


### PR DESCRIPTION
Lookbehinds are not supported by all browsers, so removing to make more compatible.

Closes #1.