### PR TITLE
Fix tag highlighting in backticks

### DIFF
--- a/src/lookml.js
+++ b/src/lookml.js
@@ -16,7 +16,7 @@ export default function (hljs) {
     };
     const BLOCK_MODE = {
         scope: "block",
-        begin: [/\w+\s*:\s*/, /\+?/, /(\w+\s*)?/, /\{(?![%\{])/],
+        begin: [/\w+\s*:\s*/, /\+?/, /(\w+\s*)?/, /\{(?![%\{])`/],
         beginScope: {
             1: "keyword",
             2: "operator",


### PR DESCRIPTION
This change adds the backtick character to the punctuation regex, which fixes `template-tag` assignment when the tags are wrapped in backticks.

Here's some example code:
```lookml
view: dim_organisations__daily {
  sql_table_name: `{{ _user_attributes['dbt_project'] }}.{{ _user_attributes['dbt_dataset'] }}.dim_organisations__daily`
    ;;
}
```

And here's the desired highlighting. Note how the tag is wrapped correctly with `template-tag`:

![image](https://user-images.githubusercontent.com/8672171/234988993-89dce7b3-c3d0-4018-bbd8-e51cfd45e856.png)
